### PR TITLE
Fix items placement on A4-Basic_style

### DIFF
--- a/src/templates/Generic/A4-Basic_style.html
+++ b/src/templates/Generic/A4-Basic_style.html
@@ -115,7 +115,7 @@
     display: grid;
     grid-template-rows: auto auto auto;
     grid-template-columns: 1fr;
-    align-items: space-between;
+    place-items: center;
 
     /* Allow us to float the claimed badge at the top right */
     position: relative;


### PR DESCRIPTION
Use place-items to center to make it easier to add and remove items. It was using an invalid value for "grid".