### PR TITLE
feat(redemption): Paytaca support

### DIFF
--- a/src/components/ReclaimDialog.vue
+++ b/src/components/ReclaimDialog.vue
@@ -13,9 +13,7 @@
           <q-input
             :label="t('payoutAddress')"
             v-model="state.payoutAddress"
-            :rules="[
-              (val) => Address.isValid(val) || t('invalidBCHAddress'),
-            ]"
+            :rules="[(val) => Address.isValid(val) || t('invalidBCHAddress')]"
             filled
           />
           <q-btn

--- a/src/pages/CreatePage.vue
+++ b/src/pages/CreatePage.vue
@@ -12,7 +12,9 @@
         </div>
 
         <!-- Subtitle -->
-        <div class="flex justify-center text-center text-h6 text-weight-medium q-mb-md">
+        <div
+          class="flex justify-center text-center text-h6 text-weight-medium q-mb-md"
+        >
           {{ t('subtitle') }}
         </div>
 

--- a/src/pages/RedeemPage.i18n.json
+++ b/src/pages/RedeemPage.i18n.json
@@ -6,9 +6,10 @@
       "spend": "Spend",
       "installInstructions": {
         "before": "Install the",
-        "wallet": "Bitcoin.com Wallet",
         "after": "on your device."
       },
+      "clickInstructions": "Click the button below to redeem the BCH into your wallet",
+      "sweepButton": "Sweep into wallet!",
       "scanInstructions": "In your wallet, click the scan button and then scan your QR Code to sweep the amount into your wallet.",
       "nearbyMerchants": "Nearby Merchants",
       "onlineServices": "Online Services",
@@ -21,9 +22,10 @@
       "spend": "Gastar",
       "installInstructions": {
         "before": "Instala la",
-        "wallet": "Billetera Bitcoin.com",
         "after": "en tu dispositivo."
       },
+      "clickInstructions": "Haz clic en el botón de abajo para canjear el BCH en tu billetera",
+      "sweepButton": "¡Barrido en la billetera!",
       "scanInstructions": "En tu billetera, haz clic en el botón de escanear y luego escanea tu Código QR para transferir el monto a tu billetera.",
       "nearbyMerchants": "Comerciantes Cercanos",
       "onlineServices": "Servicios en Línea",

--- a/src/pages/RedeemPage.vue
+++ b/src/pages/RedeemPage.vue
@@ -62,19 +62,13 @@
                 </div>
 
                 <div>
-                  <a
-                    :href="walletOptions.playStore"
-                    target="_blank"
-                  >
+                  <a :href="walletOptions.playStore" target="_blank">
                     <img src="/google-play.webp" />
                   </a>
                 </div>
 
                 <div>
-                  <a
-                    :href="walletOptions.appStore"
-                    target="_blank"
-                  >
+                  <a :href="walletOptions.appStore" target="_blank">
                     <img src="/apple-store.webp" />
                   </a>
                 </div>
@@ -89,8 +83,13 @@
               <div class="flex column text-center q-col-gutter-y-lg">
                 <!-- If the Wallet supports protocol handlers (e.g. bch-wif:${wif}), show a button... -->
                 <template v-if="walletOptions.protohandler && wifURL">
-                  <div class="flex column text-center q-col-gutter-y-lg" style="width: 496px; max-width: 100%">
-                    <div class="text-weight-bold">{{ t('clickInstructions') }}</div>
+                  <div
+                    class="flex column text-center q-col-gutter-y-lg"
+                    style="width: 496px; max-width: 100%"
+                  >
+                    <div class="text-weight-bold">
+                      {{ t('clickInstructions') }}
+                    </div>
                     <div class="column q-gutter-y-lg">
                       <q-btn
                         icon="img:bch.svg"
@@ -211,23 +210,26 @@ const walletOptions = computed(() => {
   const walletQuery = $route.query['w'];
 
   // p = Payaca Wallet
-  if(walletQuery === 'p') {
+  if (walletQuery === 'p') {
     return {
-      'name': 'Paytaca Wallet',
-      'playStore': 'https://play.google.com/store/apps/details?id=com.paytaca.app',
-      'appStore': 'https://apps.apple.com/app/paytaca/id1451795432',
+      name: 'Paytaca Wallet',
+      playStore:
+        'https://play.google.com/store/apps/details?id=com.paytaca.app',
+      appStore: 'https://apps.apple.com/app/paytaca/id1451795432',
       // TODO: Paytaca will be changing this to "bch-wif" soon.
-      'protohandler': 'bitcoincash',
-    }
+      protohandler: 'bitcoincash',
+    };
   }
 
   // Default (Bitcoin.com)
   return {
-    'name': 'Bitcoin.com Wallet',
-    'playStore': 'https://play.google.com/store/apps/details?id=com.bitcoin.mwallet',
-    'appStore': 'https://apps.apple.com/us/app/bitcoin-com-crypto-defi-wallet/id1252903728',
-    'protohandler': ''
-  }
+    name: 'Bitcoin.com Wallet',
+    playStore:
+      'https://play.google.com/store/apps/details?id=com.bitcoin.mwallet',
+    appStore:
+      'https://apps.apple.com/us/app/bitcoin-com-crypto-defi-wallet/id1252903728',
+    protohandler: '',
+  };
 });
 
 const wifURL = computed(() => {

--- a/src/pages/RedeemPage.vue
+++ b/src/pages/RedeemPage.vue
@@ -55,15 +55,15 @@
               <div class="flex column text-center q-col-gutter-y-lg">
                 <div class="text-weight-bold">
                   {{ t('installInstructions.before') }}
-                  <span class="text-primary">{{
-                    t('installInstructions.wallet')
-                  }}</span>
+                  <span class="text-primary">
+                    {{ walletOptions.name }}
+                  </span>
                   {{ t('installInstructions.after') }}
                 </div>
 
                 <div>
                   <a
-                    href="https://play.google.com/store/apps/details?id=com.bitcoin.mwallet"
+                    :href="walletOptions.playStore"
                     target="_blank"
                   >
                     <img src="/google-play.webp" />
@@ -72,7 +72,7 @@
 
                 <div>
                   <a
-                    href="https://apps.apple.com/us/app/bitcoin-com-crypto-defi-wallet/id1252903728"
+                    :href="walletOptions.appStore"
                     target="_blank"
                   >
                     <img src="/apple-store.webp" />
@@ -87,13 +87,35 @@
               class="flex col-grow justify-center animated fadeIn"
             >
               <div class="flex column text-center q-col-gutter-y-lg">
-                <div class="text-weight-bold">
-                  {{ t('scanInstructions') }}
-                </div>
+                <!-- If the Wallet supports protocol handlers (e.g. bch-wif:${wif}), show a button... -->
+                <template v-if="walletOptions.protohandler && wifURL">
+                  <div class="flex column text-center q-col-gutter-y-lg" style="width: 496px; max-width: 100%">
+                    <div class="text-weight-bold">{{ t('clickInstructions') }}</div>
+                    <div class="column q-gutter-y-lg">
+                      <q-btn
+                        icon="img:bch.svg"
+                        rounded
+                        color="accent"
+                        :label="t('sweepButton')"
+                        type="a"
+                        :href="wifURL"
+                        target="_blank"
+                        size="xl"
+                        no-caps
+                      />
+                    </div>
+                  </div>
+                </template>
+                <!-- Otherwise, let's assume it's Bitcoin.com Wallet and show a screenshot. -->
+                <template v-else>
+                  <div class="text-weight-bold">
+                    {{ t('scanInstructions') }}
+                  </div>
 
-                <div>
-                  <img src="/bitcoincom-scan.png" />
-                </div>
+                  <div>
+                    <img src="/bitcoincom-scan.png" />
+                  </div>
+                </template>
               </div>
             </div>
 
@@ -165,12 +187,14 @@
 </template>
 
 <script setup lang="ts">
-import { onUnmounted, ref } from 'vue';
+import { onUnmounted, computed, ref } from 'vue';
+import { useRoute } from 'vue-router';
 import { useQuasar } from 'quasar';
 
 import { useI18n } from 'vue-i18n';
 import Translations from './RedeemPage.i18n.json';
 
+const $route = useRoute();
 const $q = useQuasar();
 
 $q.dark.set(true);
@@ -180,6 +204,47 @@ $q.dark.set(true);
 //-----------------------------------------------------------------------------
 
 const step = ref(1);
+
+const walletOptions = computed(() => {
+  // The query parameter indicating which wallet to use is "p".
+  // NOTE: We do not use Wallet's full name as we want to minimize URL length for the QR Codes.
+  const walletQuery = $route.query['w'];
+
+  // p = Payaca Wallet
+  if(walletQuery === 'p') {
+    return {
+      'name': 'Paytaca Wallet',
+      'playStore': 'https://play.google.com/store/apps/details?id=com.paytaca.app',
+      'appStore': 'https://apps.apple.com/app/paytaca/id1451795432',
+      // TODO: Paytaca will be changing this to "bch-wif" soon.
+      'protohandler': 'bitcoincash',
+    }
+  }
+
+  // Default (Bitcoin.com)
+  return {
+    'name': 'Bitcoin.com Wallet',
+    'playStore': 'https://play.google.com/store/apps/details?id=com.bitcoin.mwallet',
+    'appStore': 'https://apps.apple.com/us/app/bitcoin-com-crypto-defi-wallet/id1252903728',
+    'protohandler': ''
+  }
+});
+
+const wifURL = computed(() => {
+  // Get the WIF from the URL Query Params.
+  const wif = $route.query['wif'];
+  const protohandler = walletOptions.value.protohandler;
+
+  // If no WIF was provided, return an empty string.
+  // NOTE: Empry string because "undefined" is more painful to work with in the templates.
+  if (!wif || !protohandler) {
+    return '';
+  }
+
+  // Prepend the bitcoincash: prefix.
+  // TODO: In future, once wallets support it, this MUST change to
+  return `${protohandler}:${wif}`;
+});
 
 //-----------------------------------------------------------------------------
 // I18n


### PR DESCRIPTION
This adds Paytaca support to the Redeem Page.

This is triggered by appending a `w` query string to the Redeem Page URL. E.g.

https://stamps.cash/#/redeem?w=p

(NOTE that we use a single character to indicate wallet to save on QR Code density)

This will also allow wallets that support triggering by protohandlers (e.g. `bch-wif` or `bitcoincash`) to present a button that can be clicked instead of an instructional image.

Other wallets can be easily added in future by appending to the `walletOptions` computed property.
